### PR TITLE
Feature/blast local search pdb uris 230815

### DIFF
--- a/pylib_3.9.7/df/BlastLocalTextSearch.py
+++ b/pylib_3.9.7/df/BlastLocalTextSearch.py
@@ -170,5 +170,4 @@ class BlastLocalTextSearch(DataFunction):
         query_sequence = query_from_request(request)
         blastdb = string_input_field(request, 'blastDbPath')
         os.environ['BLASTDB'] = blastdb
-        return run_blast_search([query_sequence], request, 'Blast text search results',
-                                sequence_column_type = 'chemical/x-genbank')
+        return run_blast_search([query_sequence], request, 'Blast text search results')

--- a/pylib_3.9.7/df/BlastLocalTextSearch.py
+++ b/pylib_3.9.7/df/BlastLocalTextSearch.py
@@ -142,7 +142,7 @@ def run_blast_search(sequences: List[SeqRecord], request: DataFunctionRequest, o
 
     if 'pdbaa' in database_name:
         uri_column = ColumnData(name='URL', dataType=DataType.STRING, contentType='chemical/x-uri',
-                                properties={'Dimension': '1'}, values=uris)
+                                properties={'Dimension': '3'}, values=uris)
         columns.append(uri_column)
 
     if show_query_id:

--- a/pylib_3.9.7/df/BlastLocalTextSearch.py
+++ b/pylib_3.9.7/df/BlastLocalTextSearch.py
@@ -170,4 +170,5 @@ class BlastLocalTextSearch(DataFunction):
         query_sequence = query_from_request(request)
         blastdb = string_input_field(request, 'blastDbPath')
         os.environ['BLASTDB'] = blastdb
-        return run_blast_search([query_sequence], request, 'Blast text search results')
+        return run_blast_search([query_sequence], request, 'Blast text search results',
+                                sequence_column_type = 'chemical/x-genbank')


### PR DESCRIPTION
For Local Text Search DF, added a column to the output table containing a URL/URI to download the PDB if one of the local PDB datasets is searched - human_pdbaa, mouse_pdbaa, rat_pdbaa

I notice that the URL column is set as datatype of chemical/x-uri  but it does not get rendered with clickable links.  The "Link" property of the column is set to {$} which appears to be correct, but the content is just a text column that is not clickable.  I also tried copying the URL out of a URL column cell, but I cannot copy cell content.  All of this is also true for the BLAST Web Search.  Is this something to report to Revitty/TIBCO?