### PR TITLE
Feature/RACE-9514

### DIFF
--- a/pylib_3.9.7/df/BlastTableSearch.py
+++ b/pylib_3.9.7/df/BlastTableSearch.py
@@ -73,8 +73,10 @@ class BlastTableSearch(DataFunction):
             columns.append(multiple_alignment_column)
 
         notification = ''
-        if len(e_values) == 0 and len(scores) == 0 and len(bits) == 0:
-            notification = 'NOTE: No hits found'
+        if e_values.count(None) == len(e_values) and \
+           scores.count(None) == len(scores) and \
+           bits.count(None) == len(bits):
+            notification = 'NOTE: No hits identified'
 
         response = DataFunctionResponse(outputColumns = columns,
                                         notificationMessage = notification)

--- a/pylib_3.9.7/df/BlastTableSearch.py
+++ b/pylib_3.9.7/df/BlastTableSearch.py
@@ -72,7 +72,11 @@ class BlastTableSearch(DataFunction):
             multiple_alignment_column.insert_nulls(null_positions)
             columns.append(multiple_alignment_column)
 
+        notification = ''
+        if len(e_values) == 0 and len(scores) == 0 and len(bits) == 0:
+            notification = 'NOTE: No hits found'
+
         response = DataFunctionResponse(outputColumns = columns,
-                                        notificationMessage = '!! Notification !!')
+                                        notificationMessage = notification)
 
         return response

--- a/pylib_3.9.7/df/BlastTableSearch.py
+++ b/pylib_3.9.7/df/BlastTableSearch.py
@@ -71,5 +71,8 @@ class BlastTableSearch(DataFunction):
             multiple_alignment_column = sequences_to_column(multiple_alignments[1:], 'Aligned Sequence', True)
             multiple_alignment_column.insert_nulls(null_positions)
             columns.append(multiple_alignment_column)
-        response = DataFunctionResponse(outputColumns=columns)
+
+        response = DataFunctionResponse(outputColumns = columns,
+                                        notificationMessage = '!! Notification !!')
+
         return response

--- a/pylib_3.9.7/df/BlastTableSearch.py
+++ b/pylib_3.9.7/df/BlastTableSearch.py
@@ -72,11 +72,12 @@ class BlastTableSearch(DataFunction):
             multiple_alignment_column.insert_nulls(null_positions)
             columns.append(multiple_alignment_column)
 
-        notification = ''
+        notification = None
         if e_values.count(None) == len(e_values) and \
            scores.count(None) == len(scores) and \
            bits.count(None) == len(bits):
-            notification = 'NOTE: No hits identified'
+            notification = {'title': 'BLAST Table Search',
+                            'summary': 'No hits identified in search. Data columns will be empty.'}
 
         response = DataFunctionResponse(outputColumns = columns,
                                         notificationMessage = notification)

--- a/pylib_3.9.7/df/data_transfer.py
+++ b/pylib_3.9.7/df/data_transfer.py
@@ -214,7 +214,10 @@ class DataFunctionResponse(BaseModel):
     """
     An array of output tables
     """
-
+    notificationMessage: str = None
+    """
+    A string to hold a message sent at the end of Data Function operation as a notification
+    """
 
 class DataFunction(ABC):
     """

--- a/pylib_3.9.7/df/data_transfer.py
+++ b/pylib_3.9.7/df/data_transfer.py
@@ -214,7 +214,7 @@ class DataFunctionResponse(BaseModel):
     """
     An array of output tables
     """
-    notificationMessage: str = None
+    notificationMessage: str = ''
     """
     A string to hold a message sent at the end of Data Function operation as a notification
     """

--- a/pylib_3.9.7/df/data_transfer.py
+++ b/pylib_3.9.7/df/data_transfer.py
@@ -214,9 +214,13 @@ class DataFunctionResponse(BaseModel):
     """
     An array of output tables
     """
-    notificationMessage: str = ''
+    notificationMessage: dict = None
     """
-    A string to hold a message sent at the end of Data Function operation as a notification
+    A dictionary to hold a message sent at the end of Data Function operation as a notification
+    If None is passed, no notification is given.
+    If a notification is passed,
+        'title' and 'summary' keys are used as a title and summary of the notification box in Spotfire
+        If 'title' or 'summary' is empty or None, no notification will be given.
     """
 
 class DataFunction(ABC):


### PR DESCRIPTION
This adds a notification message to the BLAST Table Search when there are no hits and the resulting table has empty columns.

This is parallel to a PR of the same name in the publisher repo.