### PR TITLE
Add a record.id if one does not exist for GenBank record

### DIFF
--- a/pylib_3.9.7/ruse/bio/bio_data_table_helper.py
+++ b/pylib_3.9.7/ruse/bio/bio_data_table_helper.py
@@ -71,6 +71,8 @@ def genbank_base64_str_to_sequence(data: str, row_index: int) -> SeqRecord:
             genbank_str = value.decode(charset)
             with StringIO(genbank_str) as fh:
                 record = SeqIO.read(fh, 'gb')
+            if record.id == '':
+                record.id = f'row_{row_index}'
             record.annotations['__row_index__'] = str(row_index)
             return record
         except UnicodeDecodeError:

--- a/pylib_3.9.7/ruse/bio/bio_data_table_helper.py
+++ b/pylib_3.9.7/ruse/bio/bio_data_table_helper.py
@@ -71,7 +71,7 @@ def genbank_base64_str_to_sequence(data: str, row_index: int) -> SeqRecord:
             genbank_str = value.decode(charset)
             with StringIO(genbank_str) as fh:
                 record = SeqIO.read(fh, 'gb')
-            if record.id == '':
+            if not record.id:
                 record.id = f'row_{row_index}'
             record.annotations['__row_index__'] = str(row_index)
             return record


### PR DESCRIPTION
Backward compatibility fix associated with Publisher PR Bugfix/[DFX-64](https://glysadelic.atlassian.net/browse/DFX-64) AbNumbering fails after SeqLiab 231106  (https://bitbucket.org/glysadelic/publisher/pull-requests/2)