### PR TITLE
Feature/extract genbank to table 240114

### DIFF
--- a/pylib_3.9.7/df/ExtractGenbankRegions.py
+++ b/pylib_3.9.7/df/ExtractGenbankRegions.py
@@ -81,16 +81,11 @@ class ExtractGenbankRegions(DataFunction):
 
         # first find all regions - dict preserves order
         region_names_dict: Dict[str] = {}
-        finished = False  # finished is never changed to True
         for sequence, sequence_id in zip(input_sequences, sequence_ids_no_nulls):
-            if finished:
-                break  # this may never run since finished is never True
             if not sequence:
                 continue
             feature: SeqFeature
             for feature in sequence.features:
-                if finished:
-                    break  # this may never run since finished is never True
                 name = _feature_to_name(feature, feature_key, feature_qualifier)
                 if name and name not in region_names_dict:
                     region_names_dict[name] = None

--- a/pylib_3.9.7/df/ExtractGenbankRegions.py
+++ b/pylib_3.9.7/df/ExtractGenbankRegions.py
@@ -5,8 +5,8 @@ from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from df.bio_helper import column_to_sequences, sequences_to_column
-from df.data_transfer import DataFunction, DataFunctionRequest, DataFunctionResponse, \
-                             TableData, integer_input_field, string_input_field
+from df.data_transfer import DataFunction, DataFunctionRequest, DataFunctionResponse, DataType, \
+                             ColumnData, TableData, integer_input_field, string_input_field, input_field_to_column
 
 
 def _feature_to_name(feature: SeqFeature, feature_key: str, feature_qualifier: str) -> Optional[str]:
@@ -26,10 +26,11 @@ def _feature_to_name(feature: SeqFeature, feature_key: str, feature_qualifier: s
 
 
 def _extract_region(sequence: Optional[SeqRecord], feature_key: str, feature_qualifier: str, name: str) \
-        -> Optional[Seq]:
+        -> [Optional[Seq]]:
     if not sequence:
         return None
 
+    feature_sequences = []
     feature: SeqFeature
     for feature in sequence.features:
         feature_name = _feature_to_name(feature, feature_key, feature_qualifier)
@@ -44,9 +45,11 @@ def _extract_region(sequence: Optional[SeqRecord], feature_key: str, feature_qua
                 # need to create a notification here
                 continue
 
-            return SeqRecord(seq, name)
+            # return SeqRecord(seq, name)
+            feature_sequences.append(SeqRecord(seq, name, features = [feature]))
 
-    return None
+    return feature_sequences
+    # return None
 
 
 class ExtractGenbankRegions(DataFunction):
@@ -58,18 +61,28 @@ class ExtractGenbankRegions(DataFunction):
         input_column = next(iter(request.inputColumns.values()))
         input_column.remove_nulls()
         input_sequences = column_to_sequences(input_column)
+
+        sequence_ids = input_field_to_column(request, 'uiIDColumn')
+        if sequence_ids:
+            sequence_id_column_name = sequence_ids.name
+            sequence_ids_no_nulls = [seq_id for idx, seq_id in enumerate(sequence_ids.values)
+                                     if idx not in input_column.missing_null_positions]
+            # create fake ids for any missing ids
+            sequence_ids_no_nulls = [seq_id if seq_id else f'Row {i + 1}' for i, seq_id in enumerate(sequence_ids_no_nulls)]
+        else:
+            # create fake ids if no ID column was selected
+            sequence_id_column_name = 'ID'
+            sequence_ids_no_nulls = [f'Row {i + 1}' for i in range(len(input_sequences))]
+
         max_number_of_regions = integer_input_field(request, 'maximumNumberRegions')
+
         feature_key = string_input_field(request, 'featureKey')
         feature_qualifier = string_input_field(request, 'featureQualifier')
-        if not feature_qualifier:
-            generate_table = True
-        else:
-            generate_table = False
 
         # first find all regions - dict preserves order
         region_names_dict: Dict[str] = {}
         finished = False  # finished is never changed to True
-        for sequence in input_sequences:
+        for sequence, sequence_id in zip(input_sequences, sequence_ids_no_nulls):
             if finished:
                 break  # this may never run since finished is never True
             if not sequence:
@@ -86,21 +99,55 @@ class ExtractGenbankRegions(DataFunction):
 
         region_names = list(region_names_dict.keys())
         output_columns = []
+        feature_sequence_ids = []
 
         for region_name in region_names:
             feature_sequences = [_extract_region(s, feature_key, feature_qualifier, region_name)
                                  for s in input_sequences]
-            output_column = sequences_to_column(feature_sequences, f'{input_column.name} {region_name}', False)
+            feature_sequence_ids = [i for i, seq in zip(sequence_ids_no_nulls, input_sequences) if seq]
+
 
             if feature_qualifier:
+                # verify handling of list of lists
+                output_column = sequences_to_column([feature_sequence[0] if len(feature_sequence) != 0 else None
+                                                     for feature_sequence in feature_sequences],
+                                        f'{input_column.name} {region_name}', False)
                 output_column.insert_nulls(input_column.missing_null_positions)
+                output_columns.append(output_column)
 
-            output_columns.append(output_column)
+                response = DataFunctionResponse(outputColumns = output_columns)
+            else:
+                output_feature_sequences = []
+                output_feature_ids = []
+                output_feature_descr = []
+                output_feature_start = []
+                output_feature_end = []
+                for feature_seqs, sequence_id in zip(feature_sequences, feature_sequence_ids):
+                    output_feature_ids.extend([sequence_id] * len(feature_seqs))
+                    output_feature_sequences.extend(feature_seqs)
 
-        if feature_qualifier:
-            response = DataFunctionResponse(outputColumns = output_columns)
-        else:
-            output_table = TableData(tableName = f'{input_column.name} {region_name}',
-                                     columns = output_columns)
-            response = DataFunctionResponse(outputTables = [output_table])
+                    for feature_seq in feature_seqs:
+                        qualifiers = [v for k, v in feature_seq.features[0].qualifiers.items()]
+                        output_feature_descr.append(qualifiers[0][0])
+                        output_feature_start.append(feature_seq.features[0].location.start)
+                        output_feature_end.append(feature_seq.features[0].location.end)
+                        # output_feature_start.extend([feature_seq.features[0].location.start for feature_seq in feature_seqs])
+                        # output_feature_end.extend([feature_seq.features[0].location.end for feature_seq in feature_seqs])
+
+                output_columns = [
+                                  ColumnData(name = sequence_id_column_name, dataType = DataType.STRING,
+                                             values = output_feature_ids),
+                                  sequences_to_column(output_feature_sequences, f'{input_column.name} {region_name}', False),
+                                  ColumnData(name = 'Description', dataType = DataType.STRING,
+                                             values = output_feature_descr),
+                                  ColumnData(name = 'Start', dataType = DataType.INTEGER,
+                                             values = output_feature_start),
+                                  ColumnData(name = 'end', dataType = DataType.INTEGER,
+                                             values = output_feature_end)
+                ]
+
+                output_table = TableData(tableName = f'{input_column.name} {feature_key}', columns = output_columns)
+
+                response = DataFunctionResponse(outputTables = [output_table])
+
         return response

--- a/pylib_3.9.7/df/ExtractGenbankRegions.py
+++ b/pylib_3.9.7/df/ExtractGenbankRegions.py
@@ -5,33 +5,47 @@ from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from df.bio_helper import column_to_sequences, sequences_to_column
-from df.data_transfer import DataFunction, DataFunctionRequest, DataFunctionResponse, integer_input_field, \
-    string_input_field
+from df.data_transfer import DataFunction, DataFunctionRequest, DataFunctionResponse, \
+                             TableData, integer_input_field, string_input_field
 
 
 def _feature_to_name(feature: SeqFeature, feature_key: str, feature_qualifier: str) -> Optional[str]:
     if feature.type != feature_key:
         return None
-    if feature_qualifier not in feature.qualifiers:
-        return None
-    values = feature.qualifiers[feature_qualifier]
-    if not values or len(values) != 1:
-        return None
+    if feature_qualifier:
+        if feature_qualifier not in feature.qualifiers:
+            return None
+
+        values = feature.qualifiers[feature_qualifier]
+        if not values or len(values) != 1:
+            return None
+    else:
+        values = [feature_key]
+
     return values[0]
 
 
-def _extract_region(sequence: Optional[SeqRecord], feature_key: str, feature_qualifier: str, name: str) -> Optional[
-    Seq]:
+def _extract_region(sequence: Optional[SeqRecord], feature_key: str, feature_qualifier: str, name: str) \
+        -> Optional[Seq]:
     if not sequence:
         return None
+
     feature: SeqFeature
     for feature in sequence.features:
         feature_name = _feature_to_name(feature, feature_key, feature_qualifier)
+
         if not feature_name:
             continue
+
         if feature_name == name:
-            seq = feature.extract(sequence.seq)
+            try:
+                seq = feature.extract(sequence.seq)
+            except Exception as ex:
+                # need to create a notification here
+                continue
+
             return SeqRecord(seq, name)
+
     return None
 
 
@@ -47,19 +61,23 @@ class ExtractGenbankRegions(DataFunction):
         max_number_of_regions = integer_input_field(request, 'maximumNumberRegions')
         feature_key = string_input_field(request, 'featureKey')
         feature_qualifier = string_input_field(request, 'featureQualifier')
+        if not feature_qualifier:
+            generate_table = True
+        else:
+            generate_table = False
 
         # first find all regions - dict preserves order
         region_names_dict: Dict[str] = {}
-        finished = False
+        finished = False  # finished is never changed to True
         for sequence in input_sequences:
             if finished:
-                break
+                break  # this may never run since finished is never True
             if not sequence:
                 continue
             feature: SeqFeature
             for feature in sequence.features:
                 if finished:
-                    break
+                    break  # this may never run since finished is never True
                 name = _feature_to_name(feature, feature_key, feature_qualifier)
                 if name and name not in region_names_dict:
                     region_names_dict[name] = None
@@ -67,13 +85,22 @@ class ExtractGenbankRegions(DataFunction):
                         break
 
         region_names = list(region_names_dict.keys())
-
         output_columns = []
+
         for region_name in region_names:
-            feature_sequences = [_extract_region(s, feature_key, feature_qualifier, region_name) for s in
-                                 input_sequences]
+            feature_sequences = [_extract_region(s, feature_key, feature_qualifier, region_name)
+                                 for s in input_sequences]
             output_column = sequences_to_column(feature_sequences, f'{input_column.name} {region_name}', False)
-            output_column.insert_nulls(input_column.missing_null_positions)
+
+            if feature_qualifier:
+                output_column.insert_nulls(input_column.missing_null_positions)
+
             output_columns.append(output_column)
-        response = DataFunctionResponse(outputColumns=output_columns)
+
+        if feature_qualifier:
+            response = DataFunctionResponse(outputColumns = output_columns)
+        else:
+            output_table = TableData(tableName = f'{input_column.name} {region_name}',
+                                     columns = output_columns)
+            response = DataFunctionResponse(outputTables = [output_table])
         return response


### PR DESCRIPTION
Extract Genbank Sequences extended with new functionality:
* Retains old functionality - specification of Feature Key and Feature Qualifier leads to new columns in the same table
* Leaving out Feature Qualifier only extracts information at the Feature Key level
   * A new table is created
   * IDs are carried from original table to new table (to allow joins later, if wanted)
      * Tolerant to missing IDs by either creating all fake IDS (Row 1, Row 2, ...) when no ID column specified, or filling in missing values with appropriate Row #.
   * If there are multiple Feature Keys with the same name, additional rows are created in the table for each.
      * Each row is unique by one-to-many relationship of the original ID (one) with the one row per instance of a Feature Key (many) in the output table. 
   * New table shows ID (original or faked), sequence of extracted region, description extracted from the Genbank file (first Feature Qualifier for specified Feature Key), start and end sites from the original sequence.

Parallel with similar PR in DataFxns.  DataFxnPylibTest in process - new functionality breaks old tests, but a wealth of new tests are available and need to be completed.